### PR TITLE
Change InventorySystem to save per item state

### DIFF
--- a/.idea/.idea.Inventory-System/.idea/.gitignore
+++ b/.idea/.idea.Inventory-System/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/.idea.Inventory-System.iml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Inventory-System/.idea/indexLayout.xml
+++ b/.idea/.idea.Inventory-System/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Inventory-System/.idea/vcs.xml
+++ b/.idea/.idea.Inventory-System/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/Item.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/Item.cs
@@ -8,6 +8,15 @@ namespace Studio23.SS2.InventorySystem.Data
     public class Item : ItemBase
     {
         public Sprite Icon;
+        public override void AssignSerializedData(string data)
+        {
+            
+        }
+
+        public override string GetSerializedData()
+        {
+            return "";
+        }
     }
 
 }

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemBase.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemBase.cs
@@ -3,30 +3,14 @@ using System;
 using UnityEngine;
 namespace Studio23.SS2.InventorySystem.Data
 {
-    public class ItemBase : ScriptableObject, ISaveable
+    public abstract class ItemBase : ScriptableObject
     {
         public string Id;
         public string Name;
         public string Description;
 
+        public abstract void AssignSerializedData(string data);
 
-        // Just Id is probably not a unique path
-        // We don't use IDs to save these to separate files
-        // So this shouldn't matter
-        public virtual string UniqueID => Id;
-
-        public virtual void AssignSerializedData(string data)
-        {
-            // the itemBase doesn't need to save its fields
-            // as it none of them are stateful values that can change.
-            return;
-        }
-
-        public virtual string GetSerializedData()
-        {
-            // the itemBase doesn't need to load its fields
-            // as it none of them are stateful values that can change.
-            return "";
-        }
+        public abstract string GetSerializedData();
     }
 }

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemBase.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemBase.cs
@@ -1,12 +1,32 @@
+using Studio23.SS2.SaveSystem.Interfaces;
+using System;
 using UnityEngine;
-
 namespace Studio23.SS2.InventorySystem.Data
 {
-    public class ItemBase : ScriptableObject
+    public class ItemBase : ScriptableObject, ISaveable
     {
         public string Id;
         public string Name;
         public string Description;
 
+
+        // Just Id is probably not a unique path
+        // We don't use IDs to save these to separate files
+        // So this shouldn't matter
+        public virtual string UniqueID => Id;
+
+        public virtual void AssignSerializedData(string data)
+        {
+            // the itemBase doesn't need to save its fields
+            // as it none of them are stateful values that can change.
+            return;
+        }
+
+        public virtual string GetSerializedData()
+        {
+            // the itemBase doesn't need to load its fields
+            // as it none of them are stateful values that can change.
+            return "";
+        }
     }
 }

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+
+namespace Studio23.SS2.InventorySystem.Core
+{
+    /// <summary>
+    /// Stores data per Itembase
+    /// </summary>
+    [Serializable]
+    public class ItemSaveData
+    {
+        // to load an item saved data,
+        // we first need to load the correctly named SO asset
+        // from resources
+        // hence, we need the name
+        // We should not rely on the ItemBase class implementation to save that.
+        // so this saves them as separate fields
+
+        /// <summary>
+        /// the item SO's asset name
+        /// </summary>
+        public string SOName;
+        /// <summary>
+        /// The saved data for an Item's internal state
+        /// </summary>
+        public string ItemData;
+
+        public ItemSaveData(string SOName, string ItemData)
+        {
+            this.SOName = SOName;
+            this.ItemData = ItemData;
+        }
+    }
+}

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using UnityEngine;
 
-namespace Studio23.SS2.InventorySystem.Core
+namespace Studio23.SS2.InventorySystem.Data
 {
     /// <summary>
     /// Stores data per Itembase

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs.meta
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Runtime/Data/ItemSaveData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dcf563e797cff04a9f0e5177f57468d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Samples/Demo 1/Sample Data/Hint.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Samples/Demo 1/Sample Data/Hint.cs
@@ -5,4 +5,13 @@ using UnityEngine;
 public class Hint : ItemBase
 {
     public string Summary;
+    public override void AssignSerializedData(string data)
+    {
+        
+    }
+
+    public override string GetSerializedData()
+    {
+        return "";
+    }
 }

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/Tests/Runtime/BackpackFunctionalityTest.cs
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/Tests/Runtime/BackpackFunctionalityTest.cs
@@ -60,12 +60,9 @@ public class BackpackFunctionalityTest
         await Backpack.SaveInventory(false);
 
         // Act
-        List<string> itemNames = new List<string>();
-        foreach (var item in _randomSubList)
-        {
-            itemNames.Add(item.Name);
-        }
-        string itemListToBeSaved = JsonConvert.SerializeObject(itemNames, Formatting.Indented);
+        var saveData = Backpack.CreateSaveData();
+
+        string itemListToBeSaved = JsonConvert.SerializeObject(saveData, Formatting.Indented);
 
         string path = Path.Combine(Backpack.ItemsDirectory, $"{Backpack.InventoryName}.tm");
 

--- a/Assets/Packages/com.studio23.ss2.inventorysystem/package.json
+++ b/Assets/Packages/com.studio23.ss2.inventorysystem/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.studio23.ss2.inventorysystem",
-    "version": "1.2.9",
+    "version": "1.3.0",
     "displayName": "Inventory System",
     "description": "This is a boilerplate code for implementing inventory systems in unity games",
     "unity": "2022.3",


### PR DESCRIPTION
The inventory system didn't save each scriptable's state before. The save and load methods and ItemBase class were changed to allow it. Additionally, some tests assumed that inventory saved asset names only. So those tests had to be modified as well.

The save method now saves `List<ItemSaveData>`

To load an item, we first need to load the correctly named SO asset then load the item class specific data. We need the SO name before anything else. We cannot guarantee how the item subclass will want to save data. It's also error prone to expect people to save the item SO name themselves. So item SO names and item subclass specific data were saved separately as two fields in ItemSaveData. Alternative implementations could be possible as I may have missed SaveSystem details.


@coderabbitai review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to add unique items to the inventory.
	- Implemented serialization and deserialization of item data.
- **Refactor**
	- Improved code readability and maintainability in the `HasItem` method.
- **Tests**
	- Updated the `BackpackFunctionalityTest` to use the new serialization methods.
- **Chores**
	- Updated project configuration and ignored files for better version control and project management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->